### PR TITLE
Update avatar size limit to 500 KB

### DIFF
--- a/docs/account/avatar.md
+++ b/docs/account/avatar.md
@@ -4,7 +4,7 @@
 
 1. Go to [this](https://osudroid.moe/user/?action=login) site and login with your osu!droid account credentials if you haven’t logged in yet.
 2. Open the left-side drawer and click on Profile.
-3. Press “Select file” and select an image file to upload as avatar. Keep in mind that there is a file size limitation of around 1.5 MB.
+3. Press “Select file” and select an image file to upload as avatar. Keep in mind that there is a file size limitation of around 500 KB.
 4. Crop your image using the tools provided if necessary.
 5. Save your image by clicking on the blue checkmark button on the bottom-right side of your screen. You won't see any feedback upon clicking it, don't worry about it.
 6. Press “Upload” to upload your avatar.


### PR DESCRIPTION
A player reported that they were not able to set a new avatar with 686 KB file size. Upon further investigation, it appears that the website limits the file size to 2 MB (~1.5 MB with base64 encoding overhead). However, the reverse proxy configuration for HTTP request size limit is set to 1 MB.

I went with 500 KB for number convenience, and to account for the possibility that other data may be included in the request.